### PR TITLE
overflow fixed

### DIFF
--- a/style.css
+++ b/style.css
@@ -328,7 +328,7 @@ h2 {
   background: url("Image/stats-background.jpg") no-repeat center center/cover rgba(0, 0, 0, 0.518);
   background-blend-mode: darken;
   opacity: initial;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -337,14 +337,16 @@ h2 {
 .stats-main-content {
   margin: 0 auto;
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  width: 80%;
+  gap: 5rem;
+  width: 100%;
 }
 
 .extra-info {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   justify-content: center;
 }
 
@@ -641,8 +643,4 @@ h2 {
 
 /* =============== MEDIA QUERIES (MEDIUM DEVICES) =============== */
 @media screen and (max-width: 1220px) {
-  .stats-main-content {
-    flex-direction: column;
-    gap: 5rem;
-  }
 }


### PR DESCRIPTION
<img width="1412" alt="Screenshot 2022-10-11 at 6 47 45 PM" src="https://user-images.githubusercontent.com/58658277/195105500-79d078ac-96b6-46b1-9a8d-4564fde864a1.png">
Initially it was overflowing

<img width="1122" alt="Screenshot 2022-10-11 at 7 02 43 PM" src="https://user-images.githubusercontent.com/58658277/195105680-2efff372-504e-4f97-85ce-27ba41a80532.png">
Now it is like this

<img width="869" alt="Screenshot 2022-10-11 at 7 03 27 PM" src="https://user-images.githubusercontent.com/58658277/195105720-64367f68-baa5-43cb-b32f-fd910d72bc0c.png">
In Smaller screens it looks like this

JUST HAVE TO FIX THE TABLE OVERFLOW IN SMALLER SCREENS